### PR TITLE
Harden capture storage perms and redact secrets on the default save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,27 @@ Optional integration with [duck_hunt](https://github.com/teaguesterling/duck_hun
 - Indexed by hash for instant deduplication
 - Gzip-compressed blobs (DuckDB reads directly)
 
+### Privacy
+Command lines routinely contain secrets, so privacy protections apply to the
+**default, always-on capture path** (not just the opt-in buffer):
+- **Exclusion**: commands matching sensitive patterns (`*password*`, `*token*`,
+  `ssh *`, `export *SECRET*`, …) are never persisted; configurable via
+  `privacy.exclude_patterns`
+- **Redaction**: recognizable secret values (`NAME_WITH_SECRET=…`,
+  `--password …`, `mysql -p<pw>`, `Bearer …`, `?api_token=…`, `ghp_…`/`AKIA…`
+  credentials) are replaced with `[REDACTED]` before storage. This is
+  best-effort pattern matching, **not a guarantee** — unusual secret shapes
+  are stored verbatim, so extend the exclude patterns for anything critical
+- **Owner-only storage**: the data root is `0700` and stored files are `0600`
+  (at least as strict as the `~/.bash_history` baseline)
+- **Escapes**: prefix a command with a space (bash users: also set
+  `HISTCONTROL=ignorespace`), set `SHQ_DISABLED=1`, or add `SHQ_EXCLUDE`
+  patterns; `shq -X …` force-captures verbatim when you really want it
+
 ### Retrospective Buffer
 Capture commands you forgot to explicitly record:
 - **Automatic**: Shell hooks save every command to a rotating buffer
-- **Privacy-first**: Extensive exclude patterns for sensitive commands
+- **Opt-in**: disabled by default; enable with `shq buffer enable`
 - **Promote when needed**: `shq save ~3` promotes buffer entry to permanent storage
 - **Configurable**: Control buffer size, age, and exclude patterns
 

--- a/bird/src/buffer.rs
+++ b/bird/src/buffer.rs
@@ -102,7 +102,8 @@ impl Buffer {
 
     /// Check if a command should be excluded from buffering.
     ///
-    /// Combines hooks.ignore_patterns and buffer.exclude_patterns.
+    /// Combines hooks.ignore_patterns, privacy.exclude_patterns (which apply
+    /// to every capture path) and buffer.exclude_patterns.
     pub fn should_exclude(&self, cmd: &str) -> bool {
         let cmd_lower = cmd.to_lowercase();
 
@@ -111,6 +112,11 @@ impl Buffer {
             if matches_glob_pattern(pattern, cmd) {
                 return true;
             }
+        }
+
+        // Global privacy exclusions
+        if crate::privacy::should_exclude(&self.config, cmd) {
+            return true;
         }
 
         // Check buffer-specific exclude patterns
@@ -377,57 +383,9 @@ impl Buffer {
     }
 }
 
-/// Simple glob pattern matching.
-///
-/// Supports:
-/// - `*` matches any sequence of characters
-/// - Case-insensitive matching for patterns with `*`
-fn matches_glob_pattern(pattern: &str, text: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern.eq_ignore_ascii_case(text);
-    }
-
-    let pattern_lower = pattern.to_lowercase();
-    let text_lower = text.to_lowercase();
-
-    let parts: Vec<&str> = pattern_lower.split('*').collect();
-
-    if parts.is_empty() {
-        return true;
-    }
-
-    let mut pos = 0;
-
-    // First part must match at start (unless pattern starts with *)
-    if !pattern_lower.starts_with('*') {
-        if !text_lower.starts_with(parts[0]) {
-            return false;
-        }
-        pos = parts[0].len();
-    }
-
-    // Middle parts must appear in order
-    for part in parts.iter().skip(if pattern_lower.starts_with('*') { 0 } else { 1 }) {
-        if part.is_empty() {
-            continue;
-        }
-        if let Some(found) = text_lower[pos..].find(part) {
-            pos += found + part.len();
-        } else {
-            return false;
-        }
-    }
-
-    // Last part must match at end (unless pattern ends with *)
-    if !pattern_lower.ends_with('*') && !parts.is_empty() {
-        let last = parts.last().unwrap();
-        if !last.is_empty() && !text_lower.ends_with(last) {
-            return false;
-        }
-    }
-
-    true
-}
+// Glob matching lives in `crate::privacy` so the buffer and the default
+// save path share one implementation.
+use crate::privacy::matches_glob_pattern;
 
 #[cfg(test)]
 mod tests {

--- a/bird/src/config.rs
+++ b/bird/src/config.rs
@@ -303,6 +303,33 @@ fn default_ignore_patterns() -> Vec<String> {
     ]
 }
 
+/// Privacy configuration applied to ALL capture paths.
+///
+/// Unlike `BufferConfig::exclude_patterns` (which only guards the opt-in
+/// retrospective buffer), these settings apply to the default, always-on
+/// save path as well.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrivacyConfig {
+    /// Command patterns that are never persisted (any capture path).
+    #[serde(default = "default_sensitive_exclude_patterns")]
+    pub exclude_patterns: Vec<String>,
+
+    /// Redact recognizable secret values (env assignments to secret-named
+    /// vars, `--password`/`-p<pw>`, `Bearer` tokens, `token=` params) from
+    /// stored command lines. Best-effort, on by default.
+    #[serde(default = "default_true")]
+    pub redact_commands: bool,
+}
+
+impl Default for PrivacyConfig {
+    fn default() -> Self {
+        Self {
+            exclude_patterns: default_sensitive_exclude_patterns(),
+            redact_commands: true,
+        }
+    }
+}
+
 /// Retrospective buffer configuration.
 ///
 /// The buffer captures output from all shell commands, allowing users to
@@ -357,6 +384,10 @@ fn default_buffer_max_age_hours() -> u32 {
 }
 
 fn default_buffer_exclude_patterns() -> Vec<String> {
+    default_sensitive_exclude_patterns()
+}
+
+fn default_sensitive_exclude_patterns() -> Vec<String> {
     vec![
         // Password/credential patterns
         "*password*".to_string(),
@@ -432,6 +463,10 @@ pub struct Config {
     /// Retrospective buffer configuration.
     #[serde(default)]
     pub buffer: BufferConfig,
+
+    /// Privacy configuration (applies to all capture paths).
+    #[serde(default)]
+    pub privacy: PrivacyConfig,
 }
 
 fn default_client_id() -> String {
@@ -467,6 +502,7 @@ impl Config {
             sync: SyncConfig::default(),
             hooks: HooksConfig::default(),
             buffer: BufferConfig::default(),
+            privacy: PrivacyConfig::default(),
         }
     }
 
@@ -483,6 +519,7 @@ impl Config {
             sync: SyncConfig::default(),
             hooks: HooksConfig::default(),
             buffer: BufferConfig::default(),
+            privacy: PrivacyConfig::default(),
         }
     }
 
@@ -519,7 +556,9 @@ impl Config {
         let config_path = self.bird_root.join("config.toml");
         let contents = toml::to_string_pretty(self)
             .map_err(|e| Error::Config(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(config_path, contents)?;
+        std::fs::write(&config_path, contents)?;
+        // Config may name remotes/credentials providers; keep it owner-only.
+        crate::perms::harden_file(&config_path);
         Ok(())
     }
 

--- a/bird/src/init.rs
+++ b/bird/src/init.rs
@@ -43,17 +43,30 @@ pub fn initialize(config: &Config) -> Result<()> {
         return Err(Error::AlreadyInitialized(bird_root.clone()));
     }
 
+    // Create the data root owner-only (0700) BEFORE anything lands in it.
+    // Captured shell history is sensitive; this must be at least as strict
+    // as the ~/.bash_history 0600 baseline.
+    crate::perms::ensure_secure_root(config)?;
+
     // Create directory structure
     create_directories(config)?;
 
     // Initialize DuckDB with schemas
     init_database(config)?;
 
+    // DuckDB creates the database file at the process umask; harden it.
+    crate::perms::harden_file(&config.db_path());
+
     // Save config
     config.save()?;
 
     // Create default event-formats.toml
     create_event_formats_config(config)?;
+
+    // Files created directly by DuckDB (database, seed parquet files) are
+    // written at the process umask; harden the whole fresh tree to
+    // owner-only (dirs 0700, files 0600).
+    crate::perms::harden_tree(&config.bird_root);
 
     Ok(())
 }

--- a/bird/src/lib.rs
+++ b/bird/src/lib.rs
@@ -8,13 +8,15 @@ pub mod context;
 pub mod error;
 pub mod format_hints;
 pub mod init;
+pub mod perms;
+pub mod privacy;
 pub mod project;
 pub mod query;
 pub mod schema;
 pub mod store;
 
 pub use buffer::{Buffer, BufferEntry, BufferMeta};
-pub use config::{BufferConfig, Config, RemoteConfig, RemoteMode, RemoteType, StorageMode, SyncConfig};
+pub use config::{BufferConfig, Config, PrivacyConfig, RemoteConfig, RemoteMode, RemoteType, StorageMode, SyncConfig};
 pub use error::{Error, Result};
 pub use format_hints::{FormatHint, FormatHints};
 pub use project::{find_current_project, find_project, is_in_project, ProjectInfo};

--- a/bird/src/perms.rs
+++ b/bird/src/perms.rs
@@ -1,0 +1,150 @@
+//! Storage permission hardening.
+//!
+//! Shell history contains sensitive material, so everything BIRD stores must
+//! be owner-only — at least as strict as the `~/.bash_history` (0600)
+//! baseline this tool replaces:
+//!
+//! - the data root (`BIRD_ROOT`) is `0700`, which gates the whole tree
+//!   regardless of what a library (DuckDB) creates inside it, and
+//! - every file BIRD itself writes (DB, parquet, blobs, running output,
+//!   `errors.log`, `config.toml`) is `0600`.
+//!
+//! Files written by earlier versions at a looser umask are repaired
+//! best-effort every time the store is opened.
+
+use std::fs;
+use std::path::Path;
+
+use crate::{Config, Result};
+
+/// Owner-only directory mode.
+pub const DIR_MODE: u32 = 0o700;
+/// Owner-only file mode.
+pub const FILE_MODE: u32 = 0o600;
+
+/// Set a unix permission mode on a path.
+#[cfg(unix)]
+pub fn set_mode(path: &Path, mode: u32) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+pub fn set_mode(_path: &Path, _mode: u32) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Best-effort owner-only chmod for a directory (errors ignored).
+pub fn harden_dir(path: &Path) {
+    let _ = set_mode(path, DIR_MODE);
+}
+
+/// Best-effort owner-only chmod for a file (errors ignored).
+pub fn harden_file(path: &Path) {
+    let _ = set_mode(path, FILE_MODE);
+}
+
+/// Path of the shell-hook error log (created by shell redirection, so it
+/// inherits the shell's umask and needs repair here).
+pub fn errors_log_path(config: &Config) -> std::path::PathBuf {
+    config.bird_root.join("errors.log")
+}
+
+/// Create the data root if needed and enforce `0700` on it.
+///
+/// The root chmod is a hard requirement at initialization time: if we cannot
+/// make the root owner-only we refuse to proceed, because everything under
+/// it is captured command history.
+pub fn ensure_secure_root(config: &Config) -> Result<()> {
+    let root = &config.bird_root;
+    if !root.exists() {
+        fs::create_dir_all(root)?;
+    }
+    set_mode(root, DIR_MODE)?;
+    Ok(())
+}
+
+/// Recursively harden a directory tree: directories 0700, files 0600.
+///
+/// Best-effort (per-entry errors ignored). Intended for small trees, e.g.
+/// a freshly initialized data root where DuckDB has just created the
+/// database and seed files at the process umask.
+pub fn harden_tree(path: &Path) {
+    if path.is_dir() {
+        harden_dir(path);
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                harden_tree(&entry.path());
+            }
+        }
+    } else {
+        harden_file(path);
+    }
+}
+
+/// Best-effort permission repair for an existing installation.
+///
+/// Called on every store open: re-hardens the root and the well-known
+/// sensitive files near the top of the tree (DB, WAL, error log, config,
+/// running dir). Deeper files (old parquet/blobs) are gated by the root's
+/// `0700` and are re-created hardened as data churns.
+pub fn repair_permissions(config: &Config) {
+    let root = &config.bird_root;
+    harden_dir(root);
+
+    let db = config.db_path();
+    let wal = db.with_file_name(format!(
+        "{}.wal",
+        db.file_name().and_then(|n| n.to_str()).unwrap_or("bird.duckdb")
+    ));
+    for f in [db, wal, errors_log_path(config), root.join("config.toml")] {
+        if f.exists() {
+            harden_file(&f);
+        }
+    }
+    for d in [root.join("db"), config.running_dir(), config.buffer_dir()] {
+        if d.exists() {
+            harden_dir(&d);
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn mode_of(path: &Path) -> u32 {
+        fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn test_ensure_secure_root_creates_0700() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("bird-root");
+        let config = Config::with_root(&root);
+
+        ensure_secure_root(&config).unwrap();
+        assert_eq!(mode_of(&root), 0o700);
+    }
+
+    #[test]
+    fn test_repair_fixes_loose_permissions() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("bird-root");
+        let config = Config::with_root(&root);
+        fs::create_dir_all(root.join("db")).unwrap();
+        fs::write(root.join("errors.log"), b"x").unwrap();
+        fs::write(root.join("config.toml"), b"x").unwrap();
+        // Simulate a legacy loose install
+        set_mode(&root, 0o755).unwrap();
+        set_mode(&root.join("config.toml"), 0o644).unwrap();
+
+        repair_permissions(&config);
+
+        assert_eq!(mode_of(&root), 0o700);
+        assert_eq!(mode_of(&root.join("config.toml")), 0o600);
+        assert_eq!(mode_of(&root.join("errors.log")), 0o600);
+    }
+}

--- a/bird/src/privacy.rs
+++ b/bird/src/privacy.rs
@@ -1,0 +1,420 @@
+//! Privacy protections for captured commands.
+//!
+//! Two layers, both applied to the *default* capture path (not just the
+//! opt-in retrospective buffer):
+//!
+//! 1. **Exclusion** — commands matching sensitive patterns
+//!    (`config.privacy.exclude_patterns`) are not persisted at all.
+//! 2. **Redaction** — commands that are stored get a best-effort redaction
+//!    pass over recognizable secret shapes (env assignments to secret-named
+//!    variables, `--password`/`-p<pw>` values, `Bearer` tokens, `token=`
+//!    values, well-known credential prefixes like `ghp_`/`AKIA`).
+//!
+//! Redaction is **best-effort pattern matching, not a guarantee**: secrets
+//! passed in shapes we do not recognize are stored verbatim. Exclusion
+//! patterns are the stronger tool; users handling unusual secret shapes
+//! should extend `privacy.exclude_patterns` or use the leading-space /
+//! `SHQ_DISABLED` escapes.
+
+use crate::Config;
+
+/// Replacement text for redacted secret values.
+pub const REDACTED: &str = "[REDACTED]";
+
+/// Check whether a command must be excluded from persistence entirely.
+pub fn should_exclude(config: &Config, cmd: &str) -> bool {
+    config
+        .privacy
+        .exclude_patterns
+        .iter()
+        .any(|p| matches_glob_pattern(p, cmd))
+}
+
+/// Substrings that mark a `name=value` or `--name value` pair as secret.
+const SECRET_NAME_MARKERS: &[&str] = &[
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "apikey",
+    "api_key",
+    "api-key",
+    "privatekey",
+    "private_key",
+    "private-key",
+    "credential",
+    "accesskey",
+    "access_key",
+    "access-key",
+    "sessionkey",
+    "session_key",
+    "session-key",
+    "bearer",
+];
+
+/// Long-form options whose *next* argument is a secret value.
+const SECRET_VALUE_OPTIONS: &[&str] = &[
+    "--password",
+    "--passwd",
+    "--secret",
+    "--token",
+    "--api-key",
+    "--apikey",
+    "--access-token",
+    "--auth-token",
+    "--client-secret",
+    "--private-key",
+    "--session-token",
+];
+
+/// Well-known credential prefixes (redact the whole token when seen).
+const SECRET_TOKEN_PREFIXES: &[&str] = &[
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxr-",
+    "xoxs-",
+    "sk-ant-",
+];
+
+/// Commands whose attached `-p<value>` argument is a password.
+/// Deliberately narrow: `-p` means "port" or "parents" for many other tools.
+const ATTACHED_P_COMMANDS: &[&str] = &["mysql", "mysqldump", "mysqladmin", "mariadb", "mariadb-dump"];
+
+/// Redact recognizable secret values in a command line.
+///
+/// The command structure (program, flags, whitespace) is preserved; only the
+/// secret values are replaced with [`REDACTED`]. Best-effort — see module docs.
+pub fn redact_command(cmd: &str) -> String {
+    let first_word = cmd
+        .split_whitespace()
+        .next()
+        .map(|w| {
+            // basename of the executable, lowercased
+            w.rsplit('/').next().unwrap_or(w).to_ascii_lowercase()
+        })
+        .unwrap_or_default();
+    let attached_p = ATTACHED_P_COMMANDS.iter().any(|c| *c == first_word);
+
+    let mut out = String::with_capacity(cmd.len());
+    let mut redact_next_word = false;
+
+    // Walk whitespace-delimited tokens, preserving the exact whitespace.
+    let mut rest = cmd;
+    while !rest.is_empty() {
+        // Leading whitespace
+        let token_start = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..token_start]);
+        rest = &rest[token_start..];
+        if rest.is_empty() {
+            break;
+        }
+        // Token
+        let token_end = rest
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(rest.len());
+        let token = &rest[..token_end];
+        rest = &rest[token_end..];
+
+        if redact_next_word {
+            redact_next_word = false;
+            // `--password` with no value prompts interactively; the next
+            // token may be another flag rather than a secret.
+            if !token.starts_with('-') {
+                out.push_str(&replace_token_value(token));
+                continue;
+            }
+        }
+
+        let bare = trim_token(token);
+        let bare_lower = bare.to_ascii_lowercase();
+
+        // `--password foo` / `--token foo` style: flag now, value next word.
+        if SECRET_VALUE_OPTIONS.iter().any(|o| *o == bare_lower) {
+            out.push_str(token);
+            redact_next_word = true;
+            continue;
+        }
+
+        // `Bearer <token>` (e.g. inside an Authorization header argument).
+        if bare_lower == "bearer" {
+            out.push_str(token);
+            redact_next_word = true;
+            continue;
+        }
+
+        // Attached mysql-style password: `-pSECRET`.
+        if attached_p && token.starts_with("-p") && token.len() > 2 && !token.starts_with("--") {
+            out.push_str("-p");
+            out.push_str(REDACTED);
+            continue;
+        }
+
+        // Well-known credential prefixes anywhere in the token
+        // (covers `https://user:ghp_xxx@host` embeddings too).
+        if SECRET_TOKEN_PREFIXES
+            .iter()
+            .any(|p| bare_lower.contains(p))
+            || looks_like_aws_key_id(bare)
+        {
+            out.push_str(&replace_token_value(token));
+            continue;
+        }
+
+        // `name=value` pairs (env assignments, --opt=value, URL params).
+        out.push_str(&redact_kv_in_token(token));
+    }
+
+    out
+}
+
+/// AKIA/ASIA-prefixed AWS access key ids (20 uppercase alphanumerics).
+fn looks_like_aws_key_id(tok: &str) -> bool {
+    (tok.starts_with("AKIA") || tok.starts_with("ASIA"))
+        && tok.len() == 20
+        && tok.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+}
+
+/// Strip surrounding quote characters from a token for matching purposes.
+fn trim_token(token: &str) -> &str {
+    token.trim_matches(|c| c == '"' || c == '\'' || c == ':' || c == ',' || c == ';')
+}
+
+/// Replace a token's content with [REDACTED], preserving trailing quotes.
+fn replace_token_value(token: &str) -> String {
+    let mut leading = 0;
+    for c in token.chars() {
+        if c == '"' || c == '\'' {
+            leading += c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let trailing_start = token
+        .char_indices()
+        .rev()
+        .take_while(|(_, c)| *c == '"' || *c == '\'')
+        .map(|(i, _)| i)
+        .last()
+        .unwrap_or(token.len());
+    let trailing_start = trailing_start.max(leading);
+    format!(
+        "{}{}{}",
+        &token[..leading],
+        REDACTED,
+        &token[trailing_start..]
+    )
+}
+
+/// Redact `marker=value` occurrences inside a single token.
+///
+/// Handles `export AWS_SECRET_ACCESS_KEY=...`, `--password=...`, and URL
+/// query parameters like `?api_token=...` (value ends at `&`, `;`, quote,
+/// or end of token).
+fn redact_kv_in_token(token: &str) -> String {
+    let lower = token.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+    let mut out = String::with_capacity(token.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'=' {
+            // Look back at the name run [A-Za-z0-9_-] preceding '='.
+            let mut name_start = i;
+            while name_start > 0 {
+                let c = bytes[name_start - 1];
+                if c.is_ascii_alphanumeric() || c == b'_' || c == b'-' {
+                    name_start -= 1;
+                } else {
+                    break;
+                }
+            }
+            let name = &lower[name_start..i];
+            let is_secret = !name.is_empty()
+                && SECRET_NAME_MARKERS.iter().any(|m| name.contains(m));
+
+            if is_secret {
+                // Find where the value ends.
+                let value_start = i + 1;
+                let mut value_end = token.len();
+                for (j, c) in token[value_start..].char_indices() {
+                    if matches!(c, '&' | ';' | '"' | '\'') {
+                        value_end = value_start + j;
+                        break;
+                    }
+                }
+                out.push('=');
+                if value_end > value_start {
+                    out.push_str(REDACTED);
+                }
+                // The remainder may contain more k=v pairs (URL params).
+                out.push_str(&redact_kv_in_token(&token[value_end..]));
+                return out;
+            }
+        }
+        // Copy this byte's char from the original token.
+        let ch_len = token[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        out.push_str(&token[i..i + ch_len]);
+        i += ch_len;
+    }
+
+    out
+}
+
+/// Simple glob pattern matching.
+///
+/// Supports:
+/// - `*` matches any sequence of characters
+/// - Case-insensitive matching
+pub fn matches_glob_pattern(pattern: &str, text: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern.eq_ignore_ascii_case(text);
+    }
+
+    let pattern_lower = pattern.to_lowercase();
+    let text_lower = text.to_lowercase();
+
+    let parts: Vec<&str> = pattern_lower.split('*').collect();
+
+    if parts.is_empty() {
+        return true;
+    }
+
+    let mut pos = 0;
+
+    // First part must match at start (unless pattern starts with *)
+    if !pattern_lower.starts_with('*') {
+        if !text_lower.starts_with(parts[0]) {
+            return false;
+        }
+        pos = parts[0].len();
+    }
+
+    // Middle parts must appear in order
+    for part in parts.iter().skip(if pattern_lower.starts_with('*') { 0 } else { 1 }) {
+        if part.is_empty() {
+            continue;
+        }
+        if let Some(found) = text_lower[pos..].find(part) {
+            pos += found + part.len();
+        } else {
+            return false;
+        }
+    }
+
+    // Last part must match at end (unless pattern ends with *)
+    if !pattern_lower.ends_with('*') && !parts.is_empty() {
+        let last = parts.last().unwrap();
+        if !last.is_empty() && !text_lower.ends_with(last) {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redacts_secret_env_assignment() {
+        let out = redact_command("export AWS_SECRET_ACCESS_KEY=CANARY123");
+        assert!(!out.contains("CANARY123"), "secret leaked: {}", out);
+        assert!(out.starts_with("export AWS_SECRET_ACCESS_KEY="));
+        assert!(out.contains(REDACTED));
+    }
+
+    #[test]
+    fn test_redacts_password_flag_value() {
+        let out = redact_command("mysql --password=hunter2 -e 'select 1'");
+        assert!(!out.contains("hunter2"), "secret leaked: {}", out);
+
+        let out = redact_command("some-tool --password hunter2 --verbose");
+        assert!(!out.contains("hunter2"), "secret leaked: {}", out);
+        assert!(out.contains("--verbose"));
+    }
+
+    #[test]
+    fn test_redacts_mysql_attached_password() {
+        let out = redact_command("mysql -phunter2 -u root db");
+        assert!(!out.contains("hunter2"), "secret leaked: {}", out);
+        assert!(out.contains("-p[REDACTED]"));
+        assert!(out.contains("-u root db"));
+    }
+
+    #[test]
+    fn test_does_not_mangle_port_or_parents_flags() {
+        // -p means port for psql, parents for mkdir: must NOT redact.
+        assert_eq!(redact_command("psql -p5432 -h localhost"), "psql -p5432 -h localhost");
+        assert_eq!(redact_command("mkdir -p foo/bar"), "mkdir -p foo/bar");
+        assert_eq!(redact_command("cp -p a b"), "cp -p a b");
+    }
+
+    #[test]
+    fn test_redacts_bearer_token() {
+        let out = redact_command(r#"curl -H "Authorization: Bearer eyJabc.def.ghi" https://api"#);
+        assert!(!out.contains("eyJabc"), "secret leaked: {}", out);
+        assert!(out.contains("Bearer [REDACTED]\""), "quote not preserved: {}", out);
+        assert!(out.contains("https://api"));
+    }
+
+    #[test]
+    fn test_redacts_url_token_param() {
+        let out = redact_command("curl https://example.com/x?a=1&api_token=sekrit&b=2");
+        assert!(!out.contains("sekrit"), "secret leaked: {}", out);
+        assert!(out.contains("a=1"));
+        assert!(out.contains("b=2"));
+    }
+
+    #[test]
+    fn test_redacts_known_credential_prefixes() {
+        let out = redact_command("git push https://x:ghp_abcdefghijklmnop@github.com/u/r");
+        // whole token replaced (contains the credential)
+        assert!(!out.contains("ghp_abcdefghijklmnop"), "secret leaked: {}", out);
+
+        let out = redact_command("aws configure set aws_access_key_id AKIAIOSFODNN7EXAMPLE");
+        assert!(!out.contains("AKIAIOSFODNN7EXAMPLE"), "secret leaked: {}", out);
+    }
+
+    #[test]
+    fn test_leaves_benign_commands_untouched() {
+        for cmd in [
+            "cargo build --release",
+            "git status",
+            "ls -la /tmp",
+            "echo hello world",
+            "make -j8 test",
+        ] {
+            assert_eq!(redact_command(cmd), cmd);
+        }
+    }
+
+    #[test]
+    fn test_redaction_preserves_structure_multibyte() {
+        // Multibyte input must not panic and must preserve non-secret text.
+        let out = redact_command("echo héllo ★ MY_TOKEN=秘密の値 done");
+        assert!(!out.contains("秘密の値"), "secret leaked: {}", out);
+        assert!(out.contains("héllo ★"));
+        assert!(out.contains("done"));
+    }
+
+    #[test]
+    fn test_should_exclude_uses_privacy_patterns() {
+        let config = Config::with_root("/tmp/test-privacy");
+        assert!(should_exclude(&config, "export API_TOKEN=xyz"));
+        assert!(should_exclude(&config, "ssh user@host"));
+        assert!(should_exclude(&config, "printenv"));
+        assert!(!should_exclude(&config, "cargo build"));
+        assert!(!should_exclude(&config, "git status"));
+    }
+}

--- a/bird/src/query/parser.rs
+++ b/bird/src/query/parser.rs
@@ -178,10 +178,12 @@ pub fn parse_query(input: &str) -> Query {
             continue;
         }
 
-        // Unknown content, skip a character
-        if !remaining.is_empty() {
-            remaining = &remaining[1..];
-        }
+        // Unknown content, skip one character.
+        // Advance on a char boundary: `&remaining[1..]` byte-slices and
+        // panics on multibyte UTF-8 input.
+        let mut chars = remaining.chars();
+        chars.next();
+        remaining = chars.as_str();
     }
 
     query

--- a/bird/src/query/tests.rs
+++ b/bird/src/query/tests.rs
@@ -388,3 +388,26 @@ fn test_compare_op_display() {
     assert_eq!(format!("{}", CompareOp::Gte), ">=");
     assert_eq!(format!("{}", CompareOp::Lte), "<=");
 }
+
+// Multibyte / UTF-8 safety tests (regression for a byte-slice panic in the
+// "skip a character" fallback of parse_query).
+
+#[test]
+fn test_multibyte_unknown_char_does_not_panic() {
+    // '★' is 3 bytes and not alphanumeric, so it falls through every
+    // component parser into the skip-a-character branch.
+    let q = parse_query("★");
+    assert!(q.is_match_all());
+}
+
+#[test]
+fn test_multibyte_mixed_query_does_not_panic() {
+    // Multibyte garbage followed by a valid range must still parse the range.
+    let q = parse_query("→→ ~2");
+    assert_eq!(q.range, Some(RangeSelector { start: 2, end: None }));
+
+    // Emoji (4-byte) and punctuation variants
+    let _ = parse_query("💥");
+    let _ = parse_query("¡hola");
+    let _ = parse_query("★%failed");
+}

--- a/bird/src/store/atomic.rs
+++ b/bird/src/store/atomic.rs
@@ -21,7 +21,12 @@ pub fn temp_path(final_path: &Path) -> std::path::PathBuf {
 
 /// Atomically rename temp file to final path.
 /// Returns Ok(true) if renamed, Ok(false) if file already existed (dedup hit).
+///
+/// All persisted data files (parquet, blobs) funnel through here, so this is
+/// also where storage permissions are hardened to owner-only (0600) before
+/// the file becomes visible at its final path.
 pub fn rename_into_place(temp_path: &Path, final_path: &Path) -> io::Result<bool> {
+    crate::perms::set_mode(temp_path, crate::perms::FILE_MODE)?;
     match fs::rename(temp_path, final_path) {
         Ok(()) => Ok(true),
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {

--- a/bird/src/store/compact.rs
+++ b/bird/src/store/compact.rs
@@ -750,7 +750,8 @@ impl Store {
                     [],
                 )?;
 
-                // Atomic rename
+                // Atomic rename (hardened to owner-only first)
+                crate::perms::set_mode(&temp_file, crate::perms::FILE_MODE)?;
                 fs::rename(&temp_file, &dest_file)?;
 
                 // Get consolidated size

--- a/bird/src/store/mod.rs
+++ b/bird/src/store/mod.rs
@@ -278,6 +278,10 @@ impl Store {
         if !config.db_path().exists() {
             return Err(Error::NotInitialized(config.bird_root.clone()));
         }
+        // Best-effort repair: installations created before storage hardening
+        // (or files created by shell redirection / DuckDB at a loose umask)
+        // are re-chmodded to owner-only on every open.
+        crate::perms::repair_permissions(&config);
         Ok(Self { config })
     }
 

--- a/shq/src/commands.rs
+++ b/shq/src/commands.rs
@@ -28,8 +28,11 @@ impl StreamingOutput {
     fn new(config: &Config, invocation_id: uuid::Uuid) -> io::Result<Self> {
         let running_dir = config.running_dir();
         std::fs::create_dir_all(&running_dir)?;
+        bird::perms::harden_dir(&running_dir);
         let path = config.running_path(&invocation_id);
         let file = File::create(&path)?;
+        // Live command output is as sensitive as stored output: owner-only.
+        bird::perms::set_mode(&path, bird::perms::FILE_MODE)?;
         Ok(Self { file, path })
     }
 
@@ -109,7 +112,7 @@ fn contains_nosave_marker(data: &[u8]) -> bool {
 /// `format_override`: Override format detection for event extraction.
 /// `auto_compact`: If true, spawn background compaction after saving.
 /// `no_pty`: If true, use pipes instead of PTY for separate stdout/stderr capture.
-pub fn run(shell_cmd: Option<&str>, cmd_args: &[String], tag: Option<&str>, extract_override: Option<bool>, format_override: Option<&str>, auto_compact: bool, no_pty: bool) -> bird::Result<()> {
+pub fn run(shell_cmd: Option<&str>, cmd_args: &[String], tag: Option<&str>, extract_override: Option<bool>, format_override: Option<&str>, auto_compact: bool, no_pty: bool, force_capture: bool) -> bird::Result<()> {
     // Determine command string and build PTY command
     let (cmd_str, shell, args): (String, String, Vec<String>) = match shell_cmd {
         Some(cmd) => {
@@ -146,7 +149,7 @@ pub fn run(shell_cmd: Option<&str>, cmd_args: &[String], tag: Option<&str>, extr
         return run_no_pty(
             &cmd_str, &shell, &args, &cwd, invocation_id,
             tag, extract_override, format_override, auto_compact,
-            config, store,
+            config, store, force_capture,
         );
     }
 
@@ -310,10 +313,18 @@ pub fn run(shell_cmd: Option<&str>, cmd_args: &[String], tag: Option<&str>, extr
     // Collect context metadata (VCS, CI)
     let context = ContextMetadata::collect(Some(std::path::Path::new(&cwd)));
 
+    // Privacy: redact recognizable secret values from the stored command
+    // line (the command itself already ran with its real arguments).
+    let stored_cmd = if !force_capture && config.privacy.redact_commands {
+        bird::privacy::redact_command(&cmd_str)
+    } else {
+        cmd_str.clone()
+    };
+
     let mut record = InvocationRecord::with_id(
         invocation_id,
         &sid,
-        &cmd_str,
+        &stored_cmd,
         &cwd,
         exit_code,
         &config.client_id,
@@ -377,6 +388,7 @@ fn run_no_pty(
     auto_compact: bool,
     config: Config,
     store: Store,
+    force_capture: bool,
 ) -> bird::Result<()> {
     use std::io::{BufRead, BufReader};
     use std::sync::{mpsc, Arc, Mutex};
@@ -496,10 +508,17 @@ fn run_no_pty(
     // Collect context metadata (VCS, CI)
     let context = ContextMetadata::collect(Some(std::path::Path::new(cwd)));
 
+    // Privacy: redact recognizable secret values from the stored command line.
+    let stored_cmd = if !force_capture && config.privacy.redact_commands {
+        bird::privacy::redact_command(cmd_str)
+    } else {
+        cmd_str.to_string()
+    };
+
     let mut record = InvocationRecord::with_id(
         invocation_id,
         &sid,
-        cmd_str,
+        &stored_cmd,
         cwd,
         exit_code,
         &config.client_id,
@@ -644,11 +663,12 @@ pub fn save(
     tag: Option<&str>,
     quiet: bool,
     to_buffer: bool,
+    force_capture: bool,
 ) -> bird::Result<()> {
     use std::process::Command;
 
     // Read content first so we can check for nosave marker
-    let (stdout_content, stderr_content, single_content) = if stdout_file.is_some() || stderr_file.is_some() {
+    let (mut stdout_content, mut stderr_content, mut single_content) = if stdout_file.is_some() || stderr_file.is_some() {
         let stdout = stdout_file.map(std::fs::read).transpose()?;
         let stderr = stderr_file.map(std::fs::read).transpose()?;
         (stdout, stderr, None)
@@ -674,6 +694,13 @@ pub fn save(
     }
 
     let config = Config::load()?;
+
+    // Privacy: exclusion patterns apply to EVERY capture path, not just the
+    // opt-in buffer. `shq -X` (force-capture) bypasses this deliberately.
+    if !force_capture && bird::privacy::should_exclude(&config, command) {
+        return Ok(());
+    }
+
     let store = Store::open(config.clone())?;
 
     // Get current working directory
@@ -690,63 +717,24 @@ pub fn save(
         .map(|s| s.to_string())
         .unwrap_or_else(invoker_name);
 
-    // Create session and invocation records
-    let session = SessionRecord::new(
-        &sid,
-        &config.client_id,
-        &inv_name,
-        inv_pid,
-        explicit_invoker_type,
-    );
-
-    // Collect context metadata (VCS, CI)
-    let context = ContextMetadata::collect(Some(std::path::Path::new(&cwd)));
-
-    let mut inv_record = InvocationRecord::new(
-        &sid,
-        command,
-        &cwd,
-        exit_code,
-        &config.client_id,
-    )
-    .with_metadata(context.into_map());
-
-    if let Some(ms) = duration_ms {
-        inv_record = inv_record.with_duration(ms);
-    }
-    if let Some(t) = tag {
-        inv_record = inv_record.with_tag(t);
-    }
-    let inv_id = inv_record.id;
-
-    // Combine output for buffer storage
-    let combined_output: Option<Vec<u8>> = if to_buffer {
-        // For buffer, combine all output into one
-        let mut combined = Vec::new();
-        if let Some(ref content) = stdout_content {
-            combined.extend_from_slice(content);
-        }
-        if let Some(ref content) = stderr_content {
-            combined.extend_from_slice(content);
-        }
-        if let Some(ref content) = single_content {
-            combined.extend_from_slice(content);
-        }
-        if combined.is_empty() { None } else { Some(combined) }
-    } else {
-        None
-    };
-
     if to_buffer {
         // Write to buffer instead of permanent storage
         let buffer = Buffer::new(config.clone());
 
-        if !buffer.is_enabled() {
-            if !quiet {
-                eprintln!("shq: buffer not enabled, saving to permanent storage");
+        if buffer.is_enabled() {
+            // Combine all output into one stream for the buffer
+            let mut combined = Vec::new();
+            if let Some(ref content) = stdout_content {
+                combined.extend_from_slice(content);
             }
-            // Fall through to normal save
-        } else {
+            if let Some(ref content) = stderr_content {
+                combined.extend_from_slice(content);
+            }
+            if let Some(ref content) = single_content {
+                combined.extend_from_slice(content);
+            }
+            let combined_output = if combined.is_empty() { None } else { Some(combined) };
+
             match buffer.write_complete_entry(
                 command,
                 &cwd,
@@ -765,15 +753,61 @@ pub fn save(
                     // Command excluded from buffering, skip silently
                     return Ok(());
                 }
-                Err(e) => {
-                    if !quiet {
-                        eprintln!("shq: buffer write failed ({}), saving to permanent storage", e);
-                    }
-                    // Fall through to normal save
-                }
+                // Do NOT silently fall through to permanent storage: the
+                // caller asked for the buffer (with its exclusion rules and
+                // retention limits), so surface the failure instead.
+                Err(e) => return Err(e),
             }
         }
+
+        // Buffer requested but disabled (e.g. the shell hook cached buffer
+        // state at startup and the buffer was disabled afterwards). Output
+        // captured for the buffer must NOT leak into permanent storage:
+        // discard it and record metadata only.
+        if !quiet {
+            eprintln!("shq: buffer not enabled; recording command metadata only (output discarded)");
+        }
+        stdout_content = None;
+        stderr_content = None;
+        single_content = None;
     }
+
+    // Privacy: best-effort redaction of recognizable secret values on the
+    // default (permanent) save path.
+    let stored_cmd = if !force_capture && config.privacy.redact_commands {
+        bird::privacy::redact_command(command)
+    } else {
+        command.to_string()
+    };
+
+    // Create session and invocation records
+    let session = SessionRecord::new(
+        &sid,
+        &config.client_id,
+        &inv_name,
+        inv_pid,
+        explicit_invoker_type,
+    );
+
+    // Collect context metadata (VCS, CI)
+    let context = ContextMetadata::collect(Some(std::path::Path::new(&cwd)));
+
+    let mut inv_record = InvocationRecord::new(
+        &sid,
+        &stored_cmd,
+        &cwd,
+        exit_code,
+        &config.client_id,
+    )
+    .with_metadata(context.into_map());
+
+    if let Some(ms) = duration_ms {
+        inv_record = inv_record.with_duration(ms);
+    }
+    if let Some(t) = tag {
+        inv_record = inv_record.with_tag(t);
+    }
+    let inv_id = inv_record.id;
 
     // Build batch with all related records
     let mut batch = InvocationBatch::new(inv_record).with_session(session);
@@ -3318,10 +3352,19 @@ pub fn save_from_buffer(
     // Read output from buffer
     let output = buffer.read_output(&entry)?;
 
+    // Privacy: the buffer keeps the original command line (it is opt-in and
+    // owner-only); apply the same redaction as the default save path when
+    // promoting to permanent storage.
+    let stored_cmd = if config.privacy.redact_commands {
+        bird::privacy::redact_command(&meta.cmd)
+    } else {
+        meta.cmd.clone()
+    };
+
     // Create invocation record from buffer metadata
     let mut inv_record = InvocationRecord::new(
         &meta.session_id,
-        &meta.cmd,
+        &stored_cmd,
         &meta.cwd,
         meta.exit_code.unwrap_or(0),
         &config.client_id,

--- a/shq/src/hooks.rs
+++ b/shq/src/hooks.rs
@@ -80,10 +80,14 @@ fn header(shell: Shell, mode: Mode, prompt_indicator: bool) -> String {
 {setup_hint}#
 # Privacy escapes (command not recorded):
 #   - Start command with a space: " ls -la"
+#     (bash: also add ignorespace to HISTCONTROL to keep it out of shell
+#     history itself, e.g. export HISTCONTROL=ignorespace)
 #   - Start command with backslash: "\ls -la"
 #
 # Temporary disable: export SHQ_DISABLED=1
 # Exclude patterns: export SHQ_EXCLUDE="*password*:*secret*"
+# (sensitive commands are also excluded/redacted server-side by shq save;
+#  see privacy.exclude_patterns in config.toml)
 
 "#
     )
@@ -215,11 +219,31 @@ __shq_ps0_hook() {
 }
 PS0='${__shq_cmd:+$(__shq_ps0_hook)}'
 
+# Track the last-saved history number so empty-Enter (and commands kept out
+# of history, e.g. via HISTCONTROL=ignorespace) don't re-save the previous
+# command. Initialized to the current position so shell startup saves nothing.
+__shq_last_histnum=$(HISTTIMEFORMAT='' history 1 | sed 's/^[[:space:]]*\([0-9]\{1,\}\).*/\1/')
+
 # PROMPT_COMMAND hook: fires after command completes
 __shq_prompt_command() {
     local exit_code=$?
-    local cmd
-    cmd=$(HISTTIMEFORMAT='' history 1 | sed 's/^[ ]*[0-9]*[ ]*//')
+    local histline histnum cmd
+    histline=$(HISTTIMEFORMAT='' history 1)
+
+    # Parse "  <num><*| > <cmd>" precisely, keeping the command's own leading
+    # whitespace intact so the space-prefix privacy escape below works.
+    local re='^[[:space:]]*([0-9]+)[* ] (.*)$'
+    if [[ "$histline" =~ $re ]]; then
+        histnum="${BASH_REMATCH[1]}"
+        cmd="${BASH_REMATCH[2]}"
+    else
+        return
+    fi
+
+    # Dedup: unchanged history number means no new command was entered
+    # (empty Enter, Ctrl-C at the prompt, or a history-excluded command).
+    [[ "$histnum" == "$__shq_last_histnum" ]] && { __shq_cmd=""; return; }
+    __shq_last_histnum="$histnum"
 
     # Skip if disabled, empty, or privacy escape
     [[ -n "$SHQ_DISABLED" ]] && { __shq_cmd=""; return; }

--- a/shq/src/main.rs
+++ b/shq/src/main.rs
@@ -48,7 +48,7 @@ enum Commands {
         extract: bool,
 
         /// Disable event extraction (extraction is enabled by default)
-        #[arg(short = 'X', long = "no-extract", conflicts_with = "extract")]
+        #[arg(long = "no-extract", conflicts_with = "extract")]
         no_extract: bool,
 
         /// Override format detection for event extraction (e.g., gcc, pytest, cargo)
@@ -115,7 +115,7 @@ enum Commands {
         invoker_type: String,
 
         /// Disable event extraction (extraction is enabled by default)
-        #[arg(short = 'X', long = "no-extract")]
+        #[arg(long = "no-extract")]
         no_extract: bool,
 
         /// Run compaction check after saving

--- a/shq/src/main.rs
+++ b/shq/src/main.rs
@@ -11,7 +11,7 @@ mod tutorial;
 #[command(about = "Shell Query - capture and query shell command history")]
 #[command(version)]
 struct Cli {
-    /// Force shell hooks to capture this command (bypass ignore patterns)
+    /// Force capture: bypass ignore/exclude patterns and secret redaction
     #[arg(short = 'X', long = "force-capture", global = true)]
     force_capture: bool,
 
@@ -657,6 +657,7 @@ fn parse_lines_arg(s: &str) -> (usize, commands::LimitOrder) {
 
 fn main() {
     let cli = Cli::parse();
+    let force_capture = cli.force_capture;
 
     let result = match cli.command {
         Commands::Init { mode, force } => commands::init(&mode, force),
@@ -669,7 +670,7 @@ fn main() {
             } else {
                 None
             };
-            commands::run(shell_cmd.as_deref(), &cmd, tag.as_deref(), extract_override, format.as_deref(), compact, no_pty)
+            commands::run(shell_cmd.as_deref(), &cmd, tag.as_deref(), extract_override, format.as_deref(), compact, no_pty, force_capture)
         }
         Commands::Save { file, command, exit_code, duration_ms, stream, stdout_file, stderr_file, session_id, invoker_pid, invoker, invoker_type, no_extract, compact, tag, quiet, to_buffer } => {
             // Check if this is a buffer reference (~N or just a number)
@@ -703,6 +704,7 @@ fn main() {
                     tag.as_deref(),
                     quiet,
                     to_buffer,
+                    force_capture,
                 )
             } else {
                 // No buffer ref and no command - error

--- a/shq/tests/privacy.rs
+++ b/shq/tests/privacy.rs
@@ -246,8 +246,15 @@ fn test_to_buffer_with_buffer_disabled_discards_output() {
         .expect("failed to run shq sql");
     assert!(sql.status.success(), "shq sql failed: {:?}", sql);
     let stdout = String::from_utf8_lossy(&sql.stdout);
+    // Compare the count cell line-wise: the "(1 rows)" footer also contains
+    // a digit, so a substring check would false-positive.
+    let count_is_zero = stdout.lines().any(|l| l.trim() == "0");
+    let count_is_nonzero = stdout.lines().any(|l| {
+        let t = l.trim();
+        !t.is_empty() && t.chars().all(|c| c.is_ascii_digit()) && t != "0"
+    });
     assert!(
-        !stdout.contains('1'),
+        count_is_zero && !count_is_nonzero,
         "buffer-destined output silently fell through to permanent storage:\n{}",
         stdout
     );

--- a/shq/tests/privacy.rs
+++ b/shq/tests/privacy.rs
@@ -1,0 +1,385 @@
+//! Privacy and storage-hardening regression tests.
+//!
+//! These are reproduce-first tests for the class of issues where the
+//! *default* capture path stored secrets verbatim in world-readable files:
+//!
+//! 1. sensitive commands must be excluded / redacted on the default save
+//!    path (not only in the opt-in retrospective buffer),
+//! 2. the data root must be 0700 and stored files 0600,
+//! 3. `--to-buffer` must not silently fall through to permanent storage
+//!    with captured output when the buffer is disabled,
+//! 4. the bash hook's space-prefix privacy escape must work and empty-Enter
+//!    must not duplicate saves,
+//! 5. multibyte query input must not panic the parser.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+fn shq_cmd(bird_root: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_shq"));
+    cmd.env("BIRD_ROOT", bird_root);
+    cmd
+}
+
+fn init_bird(bird_root: &Path) {
+    let output = shq_cmd(bird_root)
+        .args(["init"])
+        .output()
+        .expect("failed to run shq init");
+    assert!(output.status.success(), "shq init failed: {:?}", output);
+}
+
+/// Save a command on the default path (metadata only, empty stdin).
+fn save_cmd(bird_root: &Path, extra_args: &[&str], command: &str) {
+    let mut args = vec!["save", "-c", command, "-x", "0", "-q", "--no-extract"];
+    args.extend_from_slice(extra_args);
+    let output = shq_cmd(bird_root)
+        .args(&args)
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run shq save");
+    assert!(output.status.success(), "shq save failed: {:?}", output);
+}
+
+/// Return all stored command lines.
+fn stored_commands(bird_root: &Path) -> String {
+    let output = shq_cmd(bird_root)
+        .args(["sql", "SELECT cmd FROM attempts"])
+        .output()
+        .expect("failed to run shq sql");
+    assert!(output.status.success(), "shq sql failed: {:?}", output);
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+// ============================================================================
+// 1. Default-path exclusion and redaction
+// ============================================================================
+
+#[test]
+fn test_default_save_excludes_sensitive_command() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+
+    // Matches the `export *SECRET*` sensitive pattern: must not be persisted
+    // at all on the DEFAULT save path (no --to-buffer).
+    save_cmd(tmp.path(), &[], "export AWS_SECRET_ACCESS_KEY=CANARY_EXCLUDED");
+
+    let cmds = stored_commands(tmp.path());
+    assert!(
+        !cmds.contains("CANARY_EXCLUDED"),
+        "secret-bearing command was persisted on the default path:\n{}",
+        cmds
+    );
+}
+
+#[test]
+fn test_default_save_redacts_password_value() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+
+    // `mysql ...` does not match an exclude pattern, so it IS stored — but
+    // the attached password must be redacted.
+    save_cmd(tmp.path(), &[], "mysql -pCANARY_PW -u root testdb");
+
+    let cmds = stored_commands(tmp.path());
+    assert!(
+        !cmds.contains("CANARY_PW"),
+        "password value stored verbatim on the default path:\n{}",
+        cmds
+    );
+    assert!(
+        cmds.contains("mysql") && cmds.contains("-u root testdb"),
+        "redaction should preserve the command structure:\n{}",
+        cmds
+    );
+}
+
+#[test]
+fn test_default_save_keeps_benign_command_verbatim() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+
+    save_cmd(tmp.path(), &[], "cargo build --release");
+
+    let cmds = stored_commands(tmp.path());
+    assert!(cmds.contains("cargo build --release"), "benign command mangled:\n{}", cmds);
+}
+
+#[test]
+fn test_force_capture_stores_verbatim() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+
+    // `shq -X` is the explicit opt-out from exclusion/redaction.
+    let output = shq_cmd(tmp.path())
+        .args(["-X", "save", "-c", "export MY_SECRET=CANARY_FORCED", "-x", "0", "-q", "--no-extract"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run shq -X save");
+    assert!(output.status.success(), "forced save failed: {:?}", output);
+
+    let cmds = stored_commands(tmp.path());
+    assert!(
+        cmds.contains("CANARY_FORCED"),
+        "-X/--force-capture should bypass exclusion and redaction:\n{}",
+        cmds
+    );
+}
+
+// ============================================================================
+// 2. Storage permissions
+// ============================================================================
+
+#[cfg(unix)]
+fn mode_of(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+#[cfg(unix)]
+#[test]
+fn test_data_root_and_db_are_owner_only() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("bird-root");
+    init_bird(&root);
+    save_cmd(&root, &[], "echo perms test");
+
+    assert_eq!(
+        mode_of(&root),
+        0o700,
+        "data root must be 0700 (stricter than ~/.bash_history's dir)"
+    );
+    assert_eq!(
+        mode_of(&root.join("db/bird.duckdb")),
+        0o600,
+        "database file must be 0600 (it contains command history)"
+    );
+    let config_toml = root.join("config.toml");
+    if config_toml.exists() {
+        assert_eq!(mode_of(&config_toml), 0o600, "config.toml must be 0600");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_parquet_mode_files_are_owner_only() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("bird-root");
+    let output = shq_cmd(&root)
+        .args(["init", "-m", "parquet"])
+        .output()
+        .expect("failed to run shq init");
+    assert!(output.status.success(), "shq init -m parquet failed: {:?}", output);
+
+    save_cmd(&root, &[], "echo parquet perms test");
+
+    assert_eq!(mode_of(&root), 0o700, "data root must be 0700");
+
+    // Every parquet data file must be 0600.
+    let mut parquet_files = Vec::new();
+    collect_files_with_ext(&root, "parquet", &mut parquet_files);
+    assert!(
+        !parquet_files.is_empty(),
+        "expected parquet files to be written in parquet mode"
+    );
+    for f in parquet_files {
+        assert_eq!(
+            mode_of(&f),
+            0o600,
+            "parquet file {} must be 0600",
+            f.display()
+        );
+    }
+}
+
+fn collect_files_with_ext(dir: &Path, ext: &str, out: &mut Vec<std::path::PathBuf>) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_files_with_ext(&path, ext, out);
+            } else if path.extension().map(|e| e == ext).unwrap_or(false) {
+                out.push(path);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// 3. Buffer -> permanent fall-through
+// ============================================================================
+
+#[test]
+fn test_to_buffer_with_buffer_disabled_discards_output() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+    // Buffer is disabled by default.
+
+    // Simulate a shell hook whose cached buffer state is stale: it passes
+    // --to-buffer with captured output, but the buffer is disabled.
+    let mut child = shq_cmd(tmp.path())
+        .args(["save", "-c", "echo hook-captured", "--to-buffer", "-x", "0", "--no-extract"])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn shq save");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"OUTPUT_CANARY should never reach permanent storage\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success(), "save --to-buffer failed: {:?}", output);
+
+    // The captured output must NOT have been stored permanently.
+    let sql = shq_cmd(tmp.path())
+        .args([
+            "sql",
+            "SELECT COUNT(*) AS n FROM outputs o JOIN attempts a ON o.invocation_id = a.id \
+             WHERE a.cmd LIKE '%hook-captured%'",
+        ])
+        .output()
+        .expect("failed to run shq sql");
+    assert!(sql.status.success(), "shq sql failed: {:?}", sql);
+    let stdout = String::from_utf8_lossy(&sql.stdout);
+    assert!(
+        !stdout.contains('1'),
+        "buffer-destined output silently fell through to permanent storage:\n{}",
+        stdout
+    );
+
+    // And `shq show` must not reveal it either.
+    let show = shq_cmd(tmp.path())
+        .args(["show"])
+        .output()
+        .expect("failed to run shq show");
+    assert!(
+        !String::from_utf8_lossy(&show.stdout).contains("OUTPUT_CANARY"),
+        "buffer-destined output visible via shq show"
+    );
+}
+
+// ============================================================================
+// 4. Bash hook: space-prefix escape + empty-Enter dedup
+// ============================================================================
+
+#[test]
+fn test_bash_hook_space_escape_and_dedup() {
+    // Needs a real bash.
+    if Command::new("bash").arg("--version").output().is_err() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let hook = Command::new(env!("CARGO_BIN_EXE_shq"))
+        .args(["hook", "init", "--shell", "bash", "--no-prompt-indicator"])
+        .output()
+        .expect("failed to generate bash hook");
+    assert!(hook.status.success());
+    let hook_path = tmp.path().join("hook.sh");
+    std::fs::write(&hook_path, &hook.stdout).unwrap();
+
+    let calls_path = tmp.path().join("calls.log");
+    let script = format!(
+        r#"
+# Stub shq: log save invocations, swallow everything else (e.g. buffer status).
+shq() {{
+    if [ "$1" = save ]; then
+        printf 'CALL %s\n' "$*" >> '{calls}'
+    fi
+}}
+# NOTE: no `set -o history` — in a script that would also record the
+# driver's own commands (the __shq_prompt_command calls themselves).
+# `history -s` manipulates the history list directly regardless.
+export HISTCONTROL=
+history -s "bootstrap command from a previous session"
+source '{hook}'
+
+# A real command
+history -s "echo hello"
+__shq_prompt_command
+
+# Empty Enter at the prompt: history unchanged, must NOT re-save
+__shq_prompt_command
+
+# Space-prefixed command: privacy escape, must NOT be saved
+history -s " secret peek"
+__shq_prompt_command
+
+# Give the backgrounded (disowned) save subshells time to finish
+sleep 1
+"#,
+        calls = calls_path.display(),
+        hook = hook_path.display(),
+    );
+    let script_path = tmp.path().join("driver.sh");
+    std::fs::write(&script_path, script).unwrap();
+
+    let out = Command::new("bash")
+        .arg(&script_path)
+        .env("BIRD_ROOT", tmp.path())
+        .output()
+        .expect("failed to run bash driver");
+    assert!(
+        out.status.success(),
+        "bash driver failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let calls = std::fs::read_to_string(&calls_path).unwrap_or_default();
+    let hello_saves = calls
+        .lines()
+        .filter(|l| l.contains("echo hello"))
+        .count();
+    assert_eq!(
+        hello_saves, 1,
+        "empty Enter must not re-save the previous command (HISTCMD dedup); calls:\n{}",
+        calls
+    );
+    assert!(
+        !calls.contains("secret peek"),
+        "space-prefixed command must be suppressed (privacy escape); calls:\n{}",
+        calls
+    );
+    // The bootstrap entry (pre-hook history) must not be saved either.
+    assert!(
+        !calls.contains("bootstrap command"),
+        "hook must not save pre-existing history at startup; calls:\n{}",
+        calls
+    );
+}
+
+// ============================================================================
+// 5. Multibyte query input must not panic
+// ============================================================================
+
+#[test]
+fn test_multibyte_history_query_does_not_panic() {
+    let tmp = TempDir::new().unwrap();
+    init_bird(tmp.path());
+    save_cmd(tmp.path(), &[], "echo hello");
+
+    // '★' is a 3-byte UTF-8 char that used to hit a byte-slice panic in the
+    // query parser (`&remaining[1..]`).
+    let output = shq_cmd(tmp.path())
+        .args(["history", "★"])
+        .output()
+        .expect("failed to run shq history");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "multibyte query input panicked the parser:\n{}",
+        stderr
+    );
+    assert!(
+        output.status.success(),
+        "shq history with multibyte input failed: {:?}",
+        output
+    );
+}


### PR DESCRIPTION
## Summary

Hardens capture storage permissions and applies exclusion + redaction to the **default** save path, which previously only guarded the opt-in retrospective buffer. Also fixes the related correctness items tracked in #7 (bash hook space-prefix escape, empty-Enter duplicate saves, multibyte query parser panic).

Details are in the private advisory GHSA-37vx-ppm3-hgj5 (to be published at release). Severity framing: **HIGH on shared/multi-user hosts** (others-readable storage of captured command lines under a predictable path), **MEDIUM on single-user machines**.

## What changed

### Storage permissions (bird)
- New `bird::perms` module: the data root is created/enforced `0700`; every data file BIRD writes is `0600`.
  - `atomic::rename_into_place` (the choke point for all parquet/blob writes) hardens the temp file before it becomes visible.
  - `initialize()` hardens the fresh tree (DuckDB creates the DB and seed files at the process umask).
  - `Store::open()` runs a best-effort repair on every open (root, DB, WAL, `errors.log`, `config.toml`, `running/`, `buffer/`) so existing installations converge; deeper legacy files are gated by the root `0700`.
  - `shq run` streaming output files (`running/*.out`) and `config.toml` are created `0600`.

### Privacy on the default save path (bird + shq)
- New `bird::privacy` module shared by the buffer and the default path:
  - **Exclusion**: `privacy.exclude_patterns` (same defaults as the buffer's sensitive list) now applies to `shq save` — the always-on hook path — not just the buffer.
  - **Redaction**: stored command lines get a best-effort redaction pass (secret-named `NAME=value` assignments, `--password[= ]` values, mysql-family `-p<pw>`, `Bearer` tokens, secret-named URL params, well-known credential prefixes) on `shq save`, `shq run`, and buffer promotion. Configurable via `privacy.redact_commands` (default on).
  - `shq -X` / `--force-capture` explicitly bypasses exclusion and redaction.
- **Removed the buffer-to-permanent silent fall-through**: `shq save --to-buffer` with the buffer disabled (stale hook cache) no longer stores the captured output permanently — it records metadata only (after exclusion/redaction) and says so; real buffer write errors now propagate instead of silently degrading.
- README's "Privacy-first" claim rewritten to describe what is actually guaranteed, including an explicit statement that redaction is best-effort.

### Pre-existing CLI conflict fixed on the way
- The global `-X`/`--force-capture` flag (0.1.10) collided with the `-X` short for `--no-extract` on `run`/`save`, aborting any `shq run`/`shq save` in debug builds (clap debug assertion) and leaving the option ambiguous in release builds. `-X` now belongs solely to the documented force-capture flag; `--no-extract` keeps its long form (its short form is removed — a small CLI breaking change, but the short form was unusable as shipped).

### Correctness (#7)
- **Bash hook space-prefix escape was dead code**: the `sed` that stripped the history number also consumed the command's own leading space. The hook now parses `history 1` precisely (number, `*` marker, separator) and preserves the command verbatim, so a space-prefixed command is actually suppressed. The header also documents `HISTCONTROL=ignorespace`.
- **Empty-Enter duplicate saves**: the hook tracks the last-saved history number and skips when it has not advanced (empty Enter, Ctrl-C at prompt, history-excluded commands). Also prevents saving a stale entry from the loaded history file at shell startup.
- **Multibyte query panic**: `parse_query`'s skip-a-character fallback used `&remaining[1..]` (a byte slice); it now advances on a char boundary, so multibyte input to `shq history` no longer panics (local DoS).

## Tests (reproduce-first)

All added as permanent regression tests; each failed on the parent commit and passes with the fix:
- `shq/tests/privacy.rs`: default-path exclusion, default-path redaction (structure-preserving), benign commands stored verbatim, `-X` bypass, root `0700` + DB `0600`, parquet files `0600`, buffer-disabled `--to-buffer` output discard, bash-hook space escape + empty-Enter dedup (drives a real bash), multibyte `shq history` no-panic.
- `bird/src/query/tests.rs`: multibyte parser inputs.
- `bird/src/privacy.rs` + `bird/src/perms.rs` unit tests, including false-positive guards (`psql -p5432`, `mkdir -p`, `cp -p` untouched).

## Verification status

- Red→green: at the parent of the fix commit (tests + `-X` clap fix only), the new suite fails demonstrating the issues (secret command persisted verbatim; `mysql -p<pw>` stored verbatim; data root 0775 instead of 0700; buffer-destined output stored permanently; `echo hello` saved twice on empty Enter and a space-prefixed command captured with its space stripped; parser panic at `parser.rs:183` on `★`). At the branch tip all 9 privacy tests, all 208 bird unit tests, and 5 shq unit tests pass.
- Two pre-existing `tests/integration.rs` failures in this environment are **not** caused by this change (verified at the parent commit): `test_v5_attempt_fields` expects the literal string `shq` to appear in a row whose `source_client` is `user@host` locally, and `test_metadata_vcs_context_collected` greps a VARCHAR column that the table formatter truncates at 50 chars — a long branch name pushes `commit` out of view (it passes on `main`/detached HEAD). Worth fixing separately.
- `cargo clippy`/`cargo fmt` are not installed in this environment; note CI on `main` is currently failing for prior reasons.

## Honest limitations / residual risk

- **Redaction is pattern-based and best-effort.** Secrets in shapes not modeled here (positional passwords, custom flag names, secrets inside captured *output*) are stored verbatim. Exclusion patterns and the space-prefix escape remain the stronger tools; the README now says so.
- Captured **output** (stdout/stderr from `shq run`/`shqr`) is not redacted — mitigated by 0700/0600 storage.
- `shq push` replicates already-stored (now redacted) records; no additional redaction stage was added at push time.
- Permission repair on open is best-effort for legacy deep files; the root `0700` gate is the enforced invariant. `format-hints.toml` (non-secret pattern config, written on later `format-hints` edits) relies on the root gate rather than per-file 0600.

Refs #7. Advisory GHSA-37vx-ppm3-hgj5 to be published at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n
